### PR TITLE
fix unbound variable error with default bash on mac

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -eu
 
 # SecDim Play's SDK script.
@@ -99,4 +99,4 @@ echo_stderr ""
 echo_stderr "Welcome to SecDim Level Builder v1.0"
 echo_stderr ""
 
-main "${@}"
+main "$@"


### PR DESCRIPTION
The script currently crashes on macOS as follows:
```
❯ ./build.sh

Welcome to SecDim Level Builder v1.0

./build.sh: line 102: @: unbound variable
```

The old version of bash supplied with macOS seems to dislike the argument passing syntax being used.

The newer version of bash I have installed on my machine via homebrew was not being automatically picked up by the script, because it was hardcoded to /bin/bash - using the `env` command picks up the new version. 