### PR TITLE
Update Readme, Makefile Exit Codes, Add GitHub Actions Test Workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,6 +6,8 @@ on:
     branches:
       - main
       - feedback
+    paths:
+      - 'level/**'
 
 jobs:
   test-main:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,49 @@
+name: SecDim Level Tests
+
+on:
+  workflow_dispatch:
+  pull_request:
+    branches:
+      - main
+      - feedback
+
+jobs:
+  test-main:
+    name: Test main branch
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout main branch
+        uses: actions/checkout@v6
+        with:
+          ref: main
+
+      - name: Run usability tests
+        working-directory: level
+        run: make test
+
+      - name: Run security tests
+        working-directory: level
+        run: |
+          if make securitytest; then
+            echo "Security tests have passed. This is unexpected in the main branch. The patch for this level should be in the patch branch."
+            exit 1
+          fi
+
+  test-patch:
+    name: Test patch branch
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout patch branch
+        uses: actions/checkout@v6
+        with:
+          ref: patch
+
+      - name: Run usability tests
+        working-directory: level
+        run: make test
+
+      - name: Run security tests
+        working-directory: level
+        run: make securitytest

--- a/README.adoc
+++ b/README.adoc
@@ -1,10 +1,10 @@
 = SecDim Play Challenge Builder ⚒️
 
-SecDim Play is a novel platform for learning how to find, hack and fix security vulnerabilities through wargames. 
+SecDim Play is a novel platform for learning how to find, hack and fix security vulnerabilities through wargames.
 
-We host community challenges publically on our platform for free to foster growth in the security and developer communities.
+We host community challenges publicly on our platform for free to foster growth in the security and developer communities.
 
-This SDK is for creating wargame challenges. Creating them is a straightforward process. Each challenge is an application, that has a deliberate security vulnerability which the player needs to identify and patch. 
+This SDK is for creating wargame challenges. Creating them is a straightforward process. Each challenge is an application, that has a deliberate security vulnerability which the player needs to identify and patch.
 
 These challenges comes with two kinds of tests:
 
@@ -37,8 +37,8 @@ To get the SDK, in a terminal, run `./build.sh`, then select `init` and enter a 
 This will create a directory called `level` with
 a *sample vulnerable app and test suites*.
 
-Take a look at the level folder, this contains your application. 
-The `src/` directory will contain the main application along with the two aforementioned tests. 
+Take a look at the level folder, this contains your application.
+The `src/` directory will contain the main application along with the two aforementioned tests.
 Depending on the language the tests are either in the same `src/` directory or in a separate `test/` directory.
 
 image::res/initrepo.gif[Initializing the SDK]
@@ -49,13 +49,13 @@ image::res/initrepo.gif[Initializing the SDK]
 By default, the SDK comes with an app that has a numeric overflow vulnerability. Using this as an example, you can implement your own app with your own novel take on a security vulnerability.
 This can be an entirely different vulnerability, or a different take on an existing one. You can completely refactor or even remove the app and implement your own functionality instead.
 
-TIP: Looking for an idea? https://cwe.mitre.org/top25/archive/2023/2023_top25_list.html[CWE Top 25] or https://github.com/semgrep/semgrep-rules[SemGrep Rules] have sample codes with vulnereabilities.
+TIP: Looking for an idea? https://cwe.mitre.org/top25/archive/2023/2023_top25_list.html[CWE Top 25] or https://github.com/semgrep/semgrep-rules[SemGrep Rules] have sample codes with vulnerabilities.
 
 You can use the following commands to build, run and test your app:
 
 . `make build` To build the app's container image.
 . `make run` to run the container.
-. `make test` to run the usabiity tests.
+. `make test` to run the usability tests.
 . `make securitytest` to run security tests. Security tests fail because sample app has a vulnerability. This is intended.
 . `make debug` give a shell from container and maps `src` directory from host to the container.
 
@@ -72,7 +72,7 @@ In the following example we refactor the existing application to introduce a XSS
     }
 ----
 
-== Step 3: Add usabiity test(s) 📋
+== Step 3: Add usability test(s) 📋
 
 To ensure your application is working as intended, and that the player's security patch doesn't break the core functionality, you will need to define usability tests.
 
@@ -98,7 +98,7 @@ The following is an example of usability tests for the example XSS application:
 
 == Step 4: Add security test(s) 🛡
 
-With our challenge app ready, we will now need to simulate an exploitation of the vulnerability in question. 
+With our challenge app ready, we will now need to simulate an exploitation of the vulnerability in question.
 
 We do this through security test(s), where we write a scripted hack that tests for the vulnerability.
 
@@ -124,7 +124,7 @@ image::res/securitytestfail.gif[Running the security tests for the application]
 
 == Step 5: Creating a patch 🩹
 
-To ensure the challenge is solvable, we will need to create a patch for the vulnerability. 
+To ensure the challenge is solvable, we will need to create a patch for the vulnerability.
 
 Start by making a separate branch for the patch:
 
@@ -153,7 +153,7 @@ git push
 git push -u origin patch
 ----
 
-Add `pi3ch` as one of the contributers/collaborators to your repository.
+Add `pi3ch` as one of the contributors/collaborators to your repository.
 A SecDim team member will review your level
 and will take your through the next step.
 

--- a/README.adoc
+++ b/README.adoc
@@ -186,4 +186,4 @@ Happy Patching!
 * https://cwe.mitre.org/top25/archive/2023/2023_top25_list.html[CWE Top 25]: Vulnerabilities and sample code
 * https://github.com/semgrep/semgrep-rules[SemGrep rules]: Sample insecure codes and vulnerabilities
 
-image::https://play.secdim.com/static/media/logo.84184ff1.ab3f295f.svg[SecDim Play Logo, 200, 200]
+image::https://secdim.com/assets/images/logo.svg[SecDim Play Logo, 200, 200]

--- a/lib/csharp/Makefile
+++ b/lib/csharp/Makefile
@@ -7,13 +7,13 @@ test: header build
 	echo -e "\033[1;33m\n[i] Running functionality tests\033[0m\n"
 	docker run --rm ${APP} sh -c "dotnet test --filter FullyQualifiedName~program.Tests.programUsabilityTest" \
 		&& echo -e "\033[1;32m\n[i] Well done! All functionality tests have been passed\033[0m\n"\
-		|| echo -e "\033[1;31m\n[!] Oh, no! Program has functionality bug(s)! Try again\033[0m\n"
+		|| (echo -e "\033[1;31m\n[!] Oh, no! Program has functionality bug(s)! Try again\033[0m\n"; exit 1)
 
 securitytest: header build
 	echo -e "\033[1;33m\n[i] Running security tests\033[0m\n"
 	docker run --rm ${APP} sh -c "dotnet test --filter FullyQualifiedName~program.Tests.programSecurityTest" \
 		&& echo -e "\033[1;32m\n[i] Well done! All security tests have been passed\033[0m\n"\
-		|| echo -e "\033[1;31m\n[!] Oh, no! Program has security bug(s)! Try again\033[0m\n"
+		|| (echo -e "\033[1;31m\n[!] Oh, no! Program has security bug(s)! Try again\033[0m\n"; exit 1)
 
 build: header
 	echo -e "\033[1;33m\n[i] Building the program\033[0m\n"

--- a/lib/go/Makefile
+++ b/lib/go/Makefile
@@ -7,13 +7,13 @@ test: header build
 	echo -e "\033[1;33m\n[i] Running functionality tests\033[0m\n"
 	docker run --rm ${APP} sh -c "go test -v app.go app_usability_test.go" \
 		&& echo -e "\033[1;32m\n[i] Well done! All functionality tests have been passed\033[0m\n"\
-		|| echo -e "\033[1;31m\n[!] Oh, no! Program has functionality bug(s)! Try again\033[0m\n"
+		|| (echo -e "\033[1;31m\n[!] Oh, no! Program has functionality bug(s)! Try again\033[0m\n"; exit 1)
 
 securitytest: header build
 	echo -e "\033[1;33m\n[i] Running security tests\033[0m\n"
 	docker run --rm ${APP} sh -c "go test -v app.go app_security_test.go" \
 		&& echo -e "\033[1;32m\n[i] Well done! All security tests have been passed\033[0m\n"\
-		|| echo -e "\033[1;31m\n[!] Oh, no! Program has security bug(s)! Try again\033[0m\n"
+		|| (echo -e "\033[1;31m\n[!] Oh, no! Program has security bug(s)! Try again\033[0m\n"; exit 1)
 
 build: header
 	echo -e "\033[1;33m\n[i] Building the program\033[0m\n"

--- a/lib/java/Makefile
+++ b/lib/java/Makefile
@@ -7,13 +7,13 @@ test: header build
 	echo -e "\033[1;33m\n[i] Running functionality tests\033[0m\n"
 	docker run --rm ${APP} sh -c "gradle --no-daemon --info test -g/home/gradle" \
 		&& echo -e "\033[1;32m\n[i] Well done! All functionality tests have been passed\033[0m\n"\
-		|| echo -e "\033[1;31m\n[!] Oh, no! Program has functionality bug(s)! Try again\033[0m\n"
+		|| (echo -e "\033[1;31m\n[!] Oh, no! Program has functionality bug(s)! Try again\033[0m\n"; exit 1)
 
 securitytest: header build
 	echo -e "\033[1;33m\n[i] Running security tests\033[0m\n"
 	docker run --rm ${APP} sh -c "gradle --no-daemon --info securitytest -g/home/gradle" \
 		&& echo -e "\033[1;32m\n[i] Well done! All security tests have been passed\033[0m\n"\
-		|| echo -e "\033[1;31m\n[!] Oh, no! Program has security bug(s)! Try again\033[0m\n"
+		|| (echo -e "\033[1;31m\n[!] Oh, no! Program has security bug(s)! Try again\033[0m\n"; exit 1)
 
 build: header
 	echo -e "\033[1;33m\n[i] Building the program\033[0m\n"

--- a/lib/javascript/Makefile
+++ b/lib/javascript/Makefile
@@ -7,13 +7,13 @@ test: header build
 	echo -e "\033[1;33m\n[i] Running functionality tests\033[0m\n"
 	docker run --rm ${APP} sh -c "npm test --forceExit --verbose app.test.js" \
 		&& echo -e "\033[1;32m\n[i] Well done! All functionality tests have been passed\033[0m\n"\
-		|| echo -e "\033[1;31m\n[!] Oh, no! Program has functionality bug(s)! Try again\033[0m\n"
+		|| (echo -e "\033[1;31m\n[!] Oh, no! Program has functionality bug(s)! Try again\033[0m\n"; exit 1)
 
 securitytest: header build
 	echo -e "\033[1;33m\n[i] Running security tests\033[0m\n"
 	docker run --rm ${APP} sh -c "npm test --forceExit --verbose -t appSecurity.test.js" \
 		&& echo -e "\033[1;32m\n[i] Well done! All security tests have been passed\033[0m\n"\
-		|| echo -e "\033[1;31m\n[!] Oh, no! Program has security bug(s)! Try again\033[0m\n"
+		|| (echo -e "\033[1;31m\n[!] Oh, no! Program has security bug(s)! Try again\033[0m\n"; exit 1)
 
 build: header
 	echo -e "\033[1;33m\n[i] Building the program\033[0m\n"

--- a/lib/php/Makefile
+++ b/lib/php/Makefile
@@ -7,13 +7,13 @@ test: header build
 	echo -e "\033[1;33m\n[i] Running functionality tests\033[0m\n"
 	docker run --rm ${APP} sh -c "php artisan test --filter=UsabilityTest" \
 		&& echo -e "\033[1;32m\n[i] Well done! All functionality tests have been passed\033[0m\n"\
-		|| echo -e "\033[1;31m\n[!] Oh, no! Program has functionality bug(s)! Try again\033[0m\n"
+		|| (echo -e "\033[1;31m\n[!] Oh, no! Program has functionality bug(s)! Try again\033[0m\n"; exit 1)
 
 securitytest: header build
 	echo -e "\033[1;33m\n[i] Running security tests\033[0m\n"
 	docker run --rm ${APP} sh -c "php artisan test --filter=SecurityTest" \
 		&& echo -e "\033[1;32m\n[i] Well done! All security tests have been passed\033[0m\n"\
-		|| echo -e "\033[1;31m\n[!] Oh, no! Program has security bug(s)! Try again\033[0m\n"
+		|| (echo -e "\033[1;31m\n[!] Oh, no! Program has security bug(s)! Try again\033[0m\n"; exit 1)
 
 build: header
 	echo -e "\033[1;33m\n[i] Building the program\033[0m\n"

--- a/lib/python/Makefile
+++ b/lib/python/Makefile
@@ -7,13 +7,13 @@ test: header build
 	echo -e "\033[1;33m\n[i] Running functionality tests\033[0m\n"
 	docker run --rm ${APP} sh -c "python manage.py test --no-color --noinput --keepdb program.test_usability" \
 		&& echo -e "\033[1;32m\n[i] Well done! All functionality tests have been passed\033[0m\n"\
-		|| echo -e "\033[1;31m\n[!] Oh, no! Program has functionality bug(s)! Try again\033[0m\n"
+		|| (echo -e "\033[1;31m\n[!] Oh, no! Program has functionality bug(s)! Try again\033[0m\n"; exit 1)
 
 securitytest: header build
 	echo -e "\033[1;33m\n[i] Running security tests\033[0m\n"
 	docker run --rm ${APP} sh -c "python manage.py test --no-color --noinput --keepdb program.test_security" \
 		&& echo -e "\033[1;32m\n[i] Well done! All security tests have been passed\033[0m\n"\
-		|| echo -e "\033[1;31m\n[!] Oh, no! Program has security bug(s)! Try again\033[0m\n"
+		|| (echo -e "\033[1;31m\n[!] Oh, no! Program has security bug(s)! Try again\033[0m\n"; exit 1)
 
 build: header
 	echo -e "\033[1;33m\n[i] Building the program\033[0m\n"

--- a/lib/ruby/Makefile
+++ b/lib/ruby/Makefile
@@ -7,13 +7,13 @@ test: header build
 	echo -e "\033[1;33m\n[i] Running functionality tests\033[0m\n"
 	docker run --rm ${APP} sh -c "ruby -Itest usability.test.rb" \
 		&& echo -e "\033[1;32m\n[i] Well done! All functionality tests have been passed\033[0m\n"\
-		|| echo -e "\033[1;31m\n[!] Oh, no! Program has functionality bug(s)! Try again\033[0m\n"
+		|| (echo -e "\033[1;31m\n[!] Oh, no! Program has functionality bug(s)! Try again\033[0m\n"; exit 1)
 
 securitytest: header build
 	echo -e "\033[1;33m\n[i] Running security tests\033[0m\n"
 	docker run --rm ${APP} sh -c "ruby -Itest security.test.rb" \
 		&& echo -e "\033[1;32m\n[i] Well done! All security tests have been passed\033[0m\n"\
-		|| echo -e "\033[1;31m\n[!] Oh, no! Program has security bug(s)! Try again\033[0m\n"
+		|| (echo -e "\033[1;31m\n[!] Oh, no! Program has security bug(s)! Try again\033[0m\n"; exit 1)
 
 build: header
 	echo -e "\033[1;33m\n[i] Building the program\033[0m\n"

--- a/lib/solidity/Makefile
+++ b/lib/solidity/Makefile
@@ -7,13 +7,13 @@ test: header build
 	echo -e "\033[1;33m\n[i] Running functionality tests\033[0m\n"
 	docker run --rm ${APP} "forge test --match-path test/Contract.t.sol -vv" \
 		&& echo -e "\033[1;32m\n[i] Well done! All functionality tests have been passed\033[0m\n"\
-		|| echo -e "\033[1;31m\n[!] Oh, no! Program has functionality bug(s)! Try again\033[0m\n"
+		|| (echo -e "\033[1;31m\n[!] Oh, no! Program has functionality bug(s)! Try again\033[0m\n"; exit 1)
 
 securitytest: header build
 	echo -e "\033[1;33m\n[i] Running security tests\033[0m\n"
 	docker run --rm ${APP} "forge test --match-path test/Contract.security.t.sol -vv" \
 		&& echo -e "\033[1;32m\n[i] Well done! All security tests have been passed\033[0m\n"\
-		|| echo -e "\033[1;31m\n[!] Oh, no! Program has security bug(s)! Try again\033[0m\n"
+		|| (echo -e "\033[1;31m\n[!] Oh, no! Program has security bug(s)! Try again\033[0m\n"; exit 1)
 
 build: header
 	echo -e "\033[1;33m\n[i] Building the program\033[0m\n"

--- a/lib/typescript/Makefile
+++ b/lib/typescript/Makefile
@@ -7,13 +7,13 @@ test: header build
 	echo -e "\033[1;33m\n[i] Running functionality tests\033[0m\n"
 	docker run --rm ${APP} sh -c "npm test --verbose -t usability" \
 		&& echo -e "\033[1;32m\n[i] Well done! All functionality tests have been passed\033[0m\n"\
-		|| echo -e "\033[1;31m\n[!] Oh, no! Program has functionality bug(s)! Try again\033[0m\n"
+		|| (echo -e "\033[1;31m\n[!] Oh, no! Program has functionality bug(s)! Try again\033[0m\n"; exit 1)
 
 securitytest: header build
 	echo -e "\033[1;33m\n[i] Running security tests\033[0m\n"
 	docker run --rm ${APP} sh -c "npm test --verbose -t security" \
 		&& echo -e "\033[1;32m\n[i] Well done! All security tests have been passed\033[0m\n"\
-		|| echo -e "\033[1;31m\n[!] Oh, no! Program has security bug(s)! Try again\033[0m\n"
+		|| (echo -e "\033[1;31m\n[!] Oh, no! Program has security bug(s)! Try again\033[0m\n"; exit 1)
 
 build: header
 	echo -e "\033[1;33m\n[i] Building the program\033[0m\n"


### PR DESCRIPTION
- Update typos in Readme.adoc and use primary log from [SecDim Brand](https://secdim.com/brand/) page. 
- Set exit code 1 for `make test` and `make securitytest` failures. At the moment the echo command indicating a test failure implicitly returns exit code 0. This is useful for CI tests.
- Add GitHub Actions test workflow. Will test that usability tests pass and security tests fail on the `main` branch, and both usability tests and security tests will pass on the `patch` branch. This can be triggered manually or PR to `main` or `patch` branch where `level/**` files are changed.